### PR TITLE
fix: add a visible focus ring to the logo link

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -28,7 +28,10 @@ useSeoMeta({
   <UApp>
     <UHeader>
       <template #left>
-        <NuxtLink to="/">
+        <NuxtLink
+          to="/"
+          class="focus-visible:outline-3 outline-primary/25 rounded-md p-1 -ms-1"
+        >
           <AppLogo class="w-auto h-6 shrink-0" />
         </NuxtLink>
 


### PR DESCRIPTION
The logo link had no focus style of its own, so tabbing to it fell back to the browser default. Adds the same treatment already shipping in `docs` and `calendar`:

```
focus-visible:outline-3 outline-primary/25 rounded-md p-1 -ms-1
```

`p-1 -ms-1` gives the outline room to breathe without shifting the logo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the header logo link with clearer focus visibility, rounded corners, and spacing.
  * Ensured the logo link reliably navigates to the homepage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->